### PR TITLE
xbacklight backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+lightum

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ bindir = $(prefix)/usr/bin
 docdir = $(prefix)/usr/share/doc
 mandir = $(prefix)/usr/share/man
 
-OBJ=functions.o dbus.o dbus-session.o configfile.o lightum.o
+OBJ=functions.o dbus.o dbus-session.o configfile.o lightum.o xbacklight.o
 BIN=lightum
 
 all: ${OBJ}

--- a/dbus.c
+++ b/dbus.c
@@ -15,6 +15,8 @@
 
 #include <dbus/dbus.h>
 
+extern int set_screen_xbacklight_value(int backlight);
+
 int get_screensaver_active() {
 
 	DBusConnection *connection;
@@ -382,6 +384,7 @@ int dbus_set_screen_backlight_value(int backlight, int backend) {
 
 	if (backend == 0) ret = dbus_set_screen_backlight_value_gnome(backlight); 
 	if (backend == 1) ret = dbus_set_screen_backlight_value_kde(backlight);
+	if (backend == 2) ret = set_screen_xbacklight_value(backlight);
 
 	return ret;
 }

--- a/functions.c
+++ b/functions.c
@@ -118,11 +118,10 @@ int get_screen_backlight_value() {
 		return (15*actual_backlight)/max_backlight;
 
 	} else {
-		// fallback to read the current screen backlight value using dbus
-		// we prefer to avoid this because it forks gsd-backlight-helper
-		// from gnome-settings-daemon on each call.
+		// fallback to xbacklight
+		// we prefer to avoid this because it forks xbacklight
 
-		backlight = dbus_get_screen_backlight_value();
+		backlight = get_screen_xbacklight_value();
 		ret = dbus_to_acpi_backlight(backlight);
 		return ret;
 
@@ -281,7 +280,7 @@ void signal_handler(int sig) {
 	(void) sig;
 	set_keyboard_brightness_value(0);
 	remove_pid_file();
-	printf("Killed!\n");
+	printf("Killed with %d signal!\n",sig);
 	exit(1);
 }
 
@@ -297,7 +296,6 @@ void signal_installer() {
 	signal(SIGTERM, signal_handler);
 	signal(SIGHUP, signal_handler);
 	signal(SIGQUIT, signal_handler);
-	signal(SIGCHLD, signal_handler);
 	signal(SIGABRT, signal_handler);
 	signal(SIGUSR1, config_reload);
 }

--- a/lightum.c
+++ b/lightum.c
@@ -218,8 +218,13 @@ int main(int argc, char *argv[]) {
 		if (tmp == -1) {
 			tmp = dbus_set_screen_backlight_value_kde(acpi_to_dbus_backlight(backlight_restore));
 			if (tmp == -1) {
-				fprintf (stderr, "Can't manage screen backlight on this system.\nPlease disable backlight with config option 'workmode='1' or command line switch '-w 1'.\nIf you believe this is an error, open a bug report: https://github.com/poliva/lightum/issues\n");
-				exit (1);
+				tmp = set_screen_xbacklight_value(acpi_to_dbus_backlight(backlight_restore));
+				if ( tmp == -1 ) {
+					fprintf (stderr, "Can't manage screen backlight on this system.\nPlease disable backlight with config option 'workmode='1' or command line switch '-w 1'.\nIf you believe this is an error, open a bug report: https://github.com/poliva/lightum/issues\n");
+					exit (1);
+				} else {
+					dbus_backend=2;
+				}
 			} else {
 				dbus_backend=1;	
 			}

--- a/lightum.h
+++ b/lightum.h
@@ -65,3 +65,6 @@ DBusGConnection* get_dbus_connection();
 DBusGProxy* get_dbus_proxy_manager(DBusGConnection *connection);
 DBusGProxy* get_dbus_proxy_session(DBusGConnection *connection, DBusGProxy *proxy_manager);
 int get_session_active (DBusGProxy *proxy_session);
+
+extern int get_screen_xbacklight_value();
+extern int set_screen_xbacklight_value(int backlight);

--- a/xbacklight.c
+++ b/xbacklight.c
@@ -1,0 +1,38 @@
+#include "xbacklight.h"
+
+int get_screen_xbacklight_value() {
+	FILE * f = popen( "xbacklight", "r" );
+	if ( f == 0 ) {
+		fprintf( stderr, "Could not execute\n" );
+		return -1;
+	}
+	const int BUFSIZE = 1000;
+	char buf[ BUFSIZE ];
+	while( fgets( buf, BUFSIZE,  f ) ) {
+		;
+	}
+	pclose( f );
+	return atoi(buf);
+}
+
+int set_screen_xbacklight_value(int backlight) {
+
+	char name[50];
+	sprintf(name,"xbacklight -set %d", backlight);
+
+	printf("%s\n",name);
+
+	FILE * f = popen(name , "r" );
+	if ( f == 0 ) {
+		fprintf( stderr, "Could not execute\n" );
+		return -1;
+	}
+	const int BUFSIZE = 1000;
+	char buf[ BUFSIZE ];
+	while( fgets( buf, BUFSIZE,  f ) ) {
+		;
+	}
+	pclose( f );
+
+	return 1;
+}

--- a/xbacklight.c
+++ b/xbacklight.c
@@ -18,7 +18,6 @@ int get_screen_xbacklight_value() {
 int set_screen_xbacklight_value(int backlight) {
 
 	char name[50];
-	sprintf(name,"xbacklight -set %d", backlight);
 
 	printf("%s\n",name);
 

--- a/xbacklight.h
+++ b/xbacklight.h
@@ -1,0 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int get_screen_xbacklight_value();
+int set_screen_xbacklight_value(int backlight);


### PR DESCRIPTION
I've implemented xbacklight backed for screen backlight management. It works fine for me. 
It it obvious way, I'm surprising, why did not you implemented it early? I guess, you disagree this solution by some reasons. 

Also, it will be better to use direct Xcb Randr API call, rather then forking xbacklight, but I haven't much skill to do it (I haven't found a good documentation)
