### PR TITLE
Fix workmode 3 backlight setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DESTDIR?=/
 SHELL = /bin/sh
-CC=gcc
+CC?=gcc
 CDEBUGFLAGS= -g -O2
 CFLAGS = `pkg-config --cflags dbus-1 --cflags dbus-glib-1` -Wall -Wextra -Wwrite-strings $(CDEBUGFLAGS)
 LDFLAGS= `pkg-config --libs dbus-1 --libs dbus-glib-1` $(CDEBUGFLAGS) -lX11 -lXext -lXss -lm

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 DESTDIR?=/
 SHELL = /bin/sh
-CC?=gcc
-CFLAGS = `pkg-config --cflags dbus-1 --cflags dbus-glib-1` -Wall -Wextra -Wwrite-strings -O -g
-LDFLAGS= `pkg-config --libs dbus-1 --libs dbus-glib-1` -lX11 -lXext -lXss -lm
+CC=gcc
+CDEBUGFLAGS= -g -O2
+CFLAGS = `pkg-config --cflags dbus-1 --cflags dbus-glib-1` -Wall -Wextra -Wwrite-strings $(CDEBUGFLAGS)
+LDFLAGS= `pkg-config --libs dbus-1 --libs dbus-glib-1` $(CDEBUGFLAGS) -lX11 -lXext -lXss -lm
 INSTALL = /usr/bin/install -c
 INSTALLDATA = /usr/bin/install -c -m 644
 

--- a/lightum.c
+++ b/lightum.c
@@ -205,11 +205,13 @@ int main(int argc, char *argv[]) {
 	if (!create_pid_file()) exit(1);
 
 	/* start with current brightness values */
+	brightness_restore=0;
 	if (conf.workmode == 1 || conf.workmode == 3) {
 		brightness_restore=get_keyboard_brightness_value();
 	}
 
 	/* start with current backlight values */
+	backlight_restore=0;
 	if (conf.workmode == 2 || conf.workmode == 3) {
 		backlight_restore=get_screen_backlight_value();
 
@@ -244,6 +246,9 @@ int main(int argc, char *argv[]) {
 
 	signal_installer();
 
+	connection = 0;
+	proxy_manager = 0;
+	proxy_session = 0;
 	if (!conf.ignoresession) {
 		connection = get_dbus_connection();
 		proxy_manager = get_dbus_proxy_manager(connection);

--- a/xbacklight.c
+++ b/xbacklight.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include "xbacklight.h"
 
 int get_screen_xbacklight_value() {
@@ -17,9 +18,9 @@ int get_screen_xbacklight_value() {
 
 int set_screen_xbacklight_value(int backlight) {
 
-	char name[50];
+	char name[256];
 
-	printf("%s\n",name);
+	sprintf(name, "xbacklight -set %.3d\n", backlight);
 
 	FILE * f = popen(name , "r" );
 	if ( f == 0 ) {
@@ -28,9 +29,12 @@ int set_screen_xbacklight_value(int backlight) {
 	}
 	const int BUFSIZE = 1000;
 	char buf[ BUFSIZE ];
+        errno = 0;
 	while( fgets( buf, BUFSIZE,  f ) ) {
 		;
 	}
+        if (errno != 0)
+            perror("xbacklight");
 	pclose( f );
 
 	return 1;

--- a/xbacklight.c
+++ b/xbacklight.c
@@ -20,7 +20,7 @@ int set_screen_xbacklight_value(int backlight) {
 
 	char name[256];
 
-	sprintf(name, "xbacklight -set %.3d\n", backlight);
+	snprintf(name, 256, "xbacklight -set %.3d\n", backlight);
 
 	FILE * f = popen(name , "r" );
 	if ( f == 0 ) {
@@ -29,12 +29,12 @@ int set_screen_xbacklight_value(int backlight) {
 	}
 	const int BUFSIZE = 1000;
 	char buf[ BUFSIZE ];
-        errno = 0;
+	errno = 0;
 	while( fgets( buf, BUFSIZE,  f ) ) {
 		;
 	}
-        if (errno != 0)
-            perror("xbacklight");
+	if (errno != 0)
+	    perror("xbacklight");
 	pclose( f );
 
 	return 1;


### PR DESCRIPTION
The code for setting the backlight with xbacklight (workmode 3) was incomplete. This patch finishes it.
