### PR TITLE
Adds instructions to compile from source

### DIFF
--- a/README
+++ b/README
@@ -48,4 +48,12 @@ Official Ubuntu packages are available in poliva/lightum-mba ppa:
      sudo apt-get update
      sudo apt-get install lightum
 
+Compiling from source (Tested on Ubuntu 13.04)
+
+  1. Install the build-essentials package: "sudo apt-get install build-essentials"
+  2. Clone the repository by running "git clone https://github.com/poliva/lightum111 and "cd" into the project's directory.
+  3. Install the dependencies "sudo apt-get install libxss-dev libdbus-glib-1-dev"
+  4. Run "make"
+  5. Run "sudo make install"
+
 Enjoy! :)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ Official Ubuntu packages are available in [poliva/lightum-mba ppa](https://launc
      sudo apt-get update
      sudo apt-get install lightum
      
+Compiling from source
+---------------------
+(Tested on Ubuntu 13.04)
 
+  1. Install the build-essentials package: ```sudo apt-get install build-essentials```
+  2. Clone the repository by running ```git clone https://github.com/poliva/lightum111 and ```cd``` into the project's directory.
+  3. Install the dependencies ```sudo apt-get install libxss-dev libdbus-glib-1-dev```
+  4. Run ```make```
+  5. Run ```sudo make install```
 
 Indicator applet
 ----------------


### PR DESCRIPTION
I am running Ubuntu 13.04 and there's no precompiled package for this version of Ubuntu, so I built lightum from source. I ran into a couple of hiccups as the dependencies are not documented, so I thought that adding them to the README might benefit someone who might be in the same circumstance as me.
