### PR TITLE
Changed Makefile to compile on newer Linux systems with a consolidate…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ DESTDIR?=/
 SHELL = /bin/sh
 CC?=gcc
 CDEBUGFLAGS= -g -O2
-CFLAGS = `pkg-config --cflags dbus-1 --cflags glib-2.0 --cflags gio-2.0 --cflags libsystemd-login` -Wall -Wextra -Wwrite-strings $(CDEBUGFLAGS)
-LDFLAGS= `pkg-config --libs dbus-1 --libs glib-2.0 --libs gio-2.0 --libs libsystemd-login` $(CDEBUGFLAGS) -lX11 -lXext -lXss -lm
+CFLAGS = `pkg-config --cflags dbus-1 --cflags glib-2.0 --cflags gio-2.0 --cflags libsystemd` -Wall -Wextra -Wwrite-strings $(CDEBUGFLAGS)
+LDFLAGS= `pkg-config --libs dbus-1 --libs glib-2.0 --libs gio-2.0 --libs libsystemd` $(CDEBUGFLAGS) -lX11 -lXext -lXss -lm
 INSTALL = /usr/bin/install -c
 INSTALLDATA = /usr/bin/install -c -m 644
 


### PR DESCRIPTION
…d libsystemd package (ie. Ubuntu 16.04).

This fixes the following issue encountered at compile-time:

```
Package libsystemd-login was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsystemd-login.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsystemd-login' found
In file included from functions.c:23:0:
lightum.h:2:21: fatal error: gio/gio.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'functions.o' failed
make: *** [functions.o] Error 1
```

Recommend new branch for this change.
